### PR TITLE
Fixing minor mistake in README code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,8 +180,8 @@ WordGraphs tries you give you a powerfull yet quick search api, you can either u
     
     mwg.startsWith('Cat'); // ['Cat', 'Catnip']
     mwg.endsWith('nip'); // ['Catnip', 'Turnip']
-    mwg.containsAll('C', 'nip'); // ['Catnip']
-    mwg.containsOnly('t', 'a', 'C'); // ['Cat', 'taC']
+    mwg.containsAll([ 'C', 'nip' ]); // ['Catnip']
+    mwg.containsOnly([ 't', 'a', 'C' ]); // ['Cat', 'taC']
     
 ```
 


### PR DESCRIPTION
The [`containsAny(..)`, `containsAll(..)`, and `containsOnly(..)` methods on the `WordGraph` class](https://github.com/gotenxds/WordGraphs/blob/d67b64f8b5c1c5dc0349f690fcd02f3cdc4a3560/src/wordGraph/WordGraph.ts#L43-L51) expect a single array of strings argument, rather than one or more string arguments as implied by the previous version of the README. If you pass one or more strings as shown, a JS exception is thrown because `join(..)` is called on the first argument, and that's not a valid method on a string, only on an array.

There's no `...` rest/gather in those function signatures, the way there is [for the corresponding functions in the `QueryBuilder` class](https://github.com/gotenxds/WordGraphs/blob/d67b64f8b5c1c5dc0349f690fcd02f3cdc4a3560/src/query/QueryBuilder.ts#L31-L45). I don't know if the difference is intentional here -- it certainly suprised me! -- but I treated this as a documentation fix with this PR rather than assuming to change the code signature (which could create breakage elsewhere, I imagine).